### PR TITLE
Link Card Hover Style Improvements

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -44,25 +44,6 @@
     view-transition-name: avatar;
   }
 
-  .link-card {
-    background-image: linear-gradient(90deg, #fff, #fff);
-    /* background-size: 200% 100%; */
-  }
-
-  .link-card:is(:hover, :focus-within) {
-    background-image: var(--accent-gradient);
-    /* animation: gradient-sweep 3s ease-in-out forwards; */
-  }
-
-  /* @keyframes gradient-sweep {
-    0% {
-      background-position: 0% 50%;
-    }
-    100% {
-      background-position: 100% 50%;
-    }
-  } */
-
   .primary-grid {
     --primary-grid-rgb: 0 99 93;
     --primary-grid-opacity: 0.35;
@@ -88,4 +69,17 @@
       #1b1464
     );
   }
+}
+
+.link-card::before {
+  content: "";
+  @apply absolute w-full h-full inset-0 opacity-0 transition-all duration-500 -z-[1] theme-linear-gradient rounded-lg;
+}
+
+.link-card:hover::before {
+  opacity: 1;
+}
+
+.link-card:hover .icon {
+  color: white !important;
 }

--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -12,19 +12,17 @@ interface Props {
 const { href, title, description, index = 0, highlight } = Astro.props as Props;
 ---
 
-<li
-  class="hover:scale-105 transition-all duration-300 link-card flex p-px bg-white bg-none rounded-lg w-full min-h-[250px]"
->
+<li class="list-none relative">
   <a
     href={href}
     class:list={[
-      "transition-all grid items-center lg:grid-cols-2 p-6 text-black opacity-80 rounded-lg text-base w-full",
+      "hover:scale-105 transition-all duration-300 link-card bg-white bg-none rounded-lg w-full min-h-[250px] grid items-center lg:grid-cols-2 p-6 text-black hover:text-white hover:opacity-80 text-base",
     ]}
   >
     <Icon
       icon={title}
       transitionName={`${title}-icon`}
-      className={`text-primary-green relative m-auto lg:pr-8 ${highlight ? "w-56" : "w-24"}`}
+      className={`text-primary-green relative m-auto lg:pr-8 icon transition-colors duration-300 ${highlight ? "w-56" : "w-24"}`}
     />
     <div
       class:list={["mt-8 lg:mt-0 lg:pl-8", index % 2 !== 0 && "lg:-order-1"]}

--- a/src/components/Icon.astro
+++ b/src/components/Icon.astro
@@ -35,7 +35,7 @@ switch (icon) {
 
 {
   src && (
-    <div class={className} transition:name={transitionName}>
+    <div class:list={["icon", className]} transition:name={transitionName}>
       <Fragment set:html={src} />
     </div>
   )


### PR DESCRIPTION
Update link-card hover style to reflect the linear gradient theme on the sidebar/home page. Tidy up styles a little bit, and give better transitions to the cards.

| Before | After | 
| --- | --- |
| ![image](https://github.com/user-attachments/assets/b841b95d-9174-4ec3-b408-61ca2a259f83)|![image](https://github.com/user-attachments/assets/f948d729-cb3f-497c-be83-98008dd4ef60)|